### PR TITLE
feat: add automatic 7-day outfit planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Testgit
+# 智能天气穿搭助手
+
+一个使用 Flask 构建的交互式网页应用，根据天气、气温与风力信息提供美观简约的穿搭建议，并支持自动定位你当前位置的未来 7 天天气以生成穿搭日历。
+
+## 快速开始
+
+1. 安装依赖：
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. 启动网页应用：
+   ```bash
+   python test.py
+   ```
+3. 在浏览器中访问 [http://localhost:5000](http://localhost:5000)，允许浏览器定位后即可自动获取未来 7 天的天气与穿搭建议；你也可以手动输入天气信息获取即时推荐。
+
+> 提示：自动天气功能基于 [Open-Meteo](https://open-meteo.com/) 公共接口，需要外网访问权限以及浏览器定位许可。
+
+## 逻辑复用
+
+如果只想在脚本或其他应用中复用穿搭算法，可导入 `weather_assistant.WeatherAssistant` 类，并调用 `suggest_outfit` 方法。
+
+## 开发检查
+
+提交代码前，可执行以下命令确认脚本无语法错误：
+```bash
+python -m compileall .
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0,<4
+requests>=2.31

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,408 @@
+:root {
+  color-scheme: light;
+  font-family: 'Noto Sans SC', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg-gradient: linear-gradient(135deg, #8ec5fc 0%, #e0c3fc 100%);
+  --card-bg: rgba(255, 255, 255, 0.85);
+  --text-color: #1f2937;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.08);
+  --border-color: rgba(255, 255, 255, 0.6);
+  --shadow: 0 18px 45px rgba(15, 23, 42, 0.15);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg-gradient);
+  color: var(--text-color);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow-x: hidden;
+}
+
+.background-decoration {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.55), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.35), transparent 60%),
+    radial-gradient(circle at 60% 80%, rgba(255, 255, 255, 0.4), transparent 65%);
+  filter: blur(0px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.app-header {
+  padding: 3.5rem 1.5rem 2rem;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+}
+
+.header-content {
+  max-width: 640px;
+  margin: 0 auto;
+  background: rgba(255, 255, 255, 0.55);
+  padding: 1.75rem 2rem;
+  border-radius: 24px;
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow);
+}
+
+.header-content h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.header-content p {
+  margin-top: 0.75rem;
+  margin-bottom: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(15, 23, 42, 0.8);
+}
+
+.app-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 2rem;
+  width: min(1100px, 92vw);
+  margin: 0 auto 3.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.form-card,
+.result-card,
+.auto-forecast-card {
+  background: var(--card-bg);
+  border-radius: 28px;
+  padding: 2.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow);
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.field-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.field-group.inline {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem 1.25rem;
+}
+
+label {
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+input[type='text'],
+input[type='number'] {
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.85);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type='text']:focus,
+input[type='number']:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.input-with-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.quick-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.quick-tags button {
+  border: none;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.quick-tags button:hover {
+  transform: translateY(-1px);
+  background: rgba(37, 99, 235, 0.18);
+}
+
+.field-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.error-message {
+  min-height: 1.2em;
+  margin: 0;
+  font-size: 0.8rem;
+  color: #dc2626;
+}
+
+.submit-button {
+  align-self: flex-start;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+  padding: 0.9rem 1.85rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 16px 35px rgba(124, 58, 237, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submit-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px rgba(124, 58, 237, 0.3);
+}
+
+.result-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.auto-forecast-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.forecast-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.forecast-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.forecast-status {
+  margin: 0.6rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.65);
+  transition: color 0.2s ease;
+}
+
+.forecast-status.is-error {
+  color: #b91c1c;
+}
+
+.refresh-forecast {
+  border: none;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.refresh-forecast:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.refresh-forecast:hover:not(:disabled) {
+  background: rgba(37, 99, 235, 0.22);
+  transform: translateY(-1px);
+}
+
+.forecast-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.forecast-item {
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 22px;
+  padding: 1.5rem 1.75rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.forecast-item-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.forecast-date-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.forecast-date {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.forecast-weather {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.forecast-wind {
+  align-self: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.forecast-outfit {
+  margin: 0;
+  line-height: 1.7;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.forecast-extra {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.7);
+  line-height: 1.6;
+}
+
+.forecast-extra-label {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.placeholder {
+  text-align: center;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.placeholder h2 {
+  margin-bottom: 0.75rem;
+  font-weight: 600;
+}
+
+.recommendation h2 {
+  margin: 0 0 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--accent);
+  font-size: 0.9rem;
+}
+
+.recommendation-block {
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 18px;
+  padding: 1.4rem 1.6rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  margin-bottom: 1.25rem;
+}
+
+.recommendation-block h3 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.05rem;
+  color: rgba(15, 23, 42, 0.8);
+}
+
+.recommendation-block p {
+  margin: 0;
+  line-height: 1.7;
+}
+
+.recommendation-block ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.app-footer {
+  text-align: center;
+  padding: 2rem 1.5rem 3rem;
+  color: rgba(15, 23, 42, 0.75);
+  font-size: 0.95rem;
+  position: relative;
+  z-index: 1;
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    padding-top: 2.5rem;
+  }
+
+  .header-content {
+    padding: 1.5rem;
+  }
+
+  .form-card,
+  .result-card,
+  .auto-forecast-card {
+    padding: 2rem;
+  }
+
+  .forecast-item {
+    padding: 1.25rem 1.35rem;
+  }
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,421 @@
+const form = document.getElementById('recommendation-form');
+const weatherInput = document.getElementById('weather');
+const temperatureInput = document.getElementById('temperature');
+const windInput = document.getElementById('wind');
+const submitButton = form.querySelector('.submit-button');
+
+const placeholder = document.getElementById('result-placeholder');
+const recommendationPanel = document.getElementById('recommendation');
+const outfitEl = document.getElementById('outfit');
+const accessoriesList = document.getElementById('accessories');
+const accessoriesBlock = document.getElementById('accessories-block');
+const tipsList = document.getElementById('tips');
+const tipsBlock = document.getElementById('tips-block');
+const summaryWeather = document.getElementById('summary-weather');
+const summaryTemperature = document.getElementById('summary-temperature');
+const summaryWind = document.getElementById('summary-wind');
+
+const errorElements = new Map(
+  Array.from(document.querySelectorAll('.error-message')).map((el) => [
+    el.dataset.errorFor,
+    el,
+  ]),
+);
+
+const quickButtons = document.querySelectorAll('.quick-tags button');
+quickButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    weatherInput.value = button.dataset.weather ?? '';
+    weatherInput.focus();
+  });
+});
+
+const forecastStatus = document.getElementById('forecast-status');
+const forecastList = document.getElementById('forecast-list');
+const refreshForecastButton = document.getElementById('refresh-forecast');
+
+if (refreshForecastButton) {
+  refreshForecastButton.addEventListener('click', () => {
+    requestAutoForecast(true);
+  });
+}
+
+initAutoForecast();
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  clearErrors();
+  toggleLoading(true);
+
+  const payload = {
+    weather: weatherInput.value.trim(),
+    temperature: temperatureInput.value.trim(),
+    windSpeed: windInput.value.trim(),
+  };
+
+  if (!payload.temperature) {
+    payload.temperature = null;
+  }
+  if (!payload.windSpeed) {
+    payload.windSpeed = null;
+  }
+
+  try {
+    const response = await fetch('/api/recommend', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok || !data.success) {
+      displayErrors(data.errors || { general: '请求失败，请稍后重试。' });
+      showPlaceholder(
+        data.errors?.general || data.errors?.weather || '请检查输入后再试一次。',
+      );
+      return;
+    }
+
+    renderRecommendation(data.data);
+  } catch (error) {
+    console.error(error);
+    displayErrors({ general: '网络连接异常，请稍后重试。' });
+    showPlaceholder('网络连接异常，请稍后重试。');
+  } finally {
+    toggleLoading(false);
+  }
+});
+
+function renderRecommendation(data) {
+  if (!data) {
+    showPlaceholder('暂时无法获取建议，请稍后再试。');
+    return;
+  }
+
+  placeholder.hidden = true;
+  recommendationPanel.hidden = false;
+
+  summaryWeather.textContent = weatherInput.value.trim() || '—';
+
+  if (data.outfit) {
+    outfitEl.textContent = data.outfit;
+  } else {
+    outfitEl.textContent = '暂无建议';
+  }
+
+  const temperatureValue = temperatureInput.value.trim();
+  const windValue = windInput.value.trim();
+
+  if (temperatureValue) {
+    summaryTemperature.textContent = `${temperatureValue}°C`;
+    summaryTemperature.hidden = false;
+  } else {
+    summaryTemperature.hidden = true;
+  }
+
+  if (windValue) {
+    summaryWind.textContent = `${windValue} m/s`;
+    summaryWind.hidden = false;
+  } else {
+    summaryWind.hidden = true;
+  }
+
+  renderList(accessoriesList, accessoriesBlock, data.accessories);
+  renderList(tipsList, tipsBlock, data.tips);
+}
+
+function renderList(listEl, wrapperEl, items) {
+  listEl.innerHTML = '';
+  if (!items || items.length === 0) {
+    wrapperEl.hidden = true;
+    return;
+  }
+
+  items.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    listEl.appendChild(li);
+  });
+  wrapperEl.hidden = false;
+}
+
+function showPlaceholder(message) {
+  placeholder.hidden = false;
+  recommendationPanel.hidden = true;
+  placeholder.querySelector('p').textContent = message;
+}
+
+function displayErrors(errors) {
+  if (!errors) return;
+
+  Object.entries(errors).forEach(([key, message]) => {
+    if (key === 'general') {
+      placeholder.querySelector('p').textContent = message;
+      return;
+    }
+
+    const errorEl = errorElements.get(key);
+    if (errorEl) {
+      errorEl.textContent = message;
+    }
+  });
+}
+
+function clearErrors() {
+  errorElements.forEach((el) => {
+    el.textContent = '';
+  });
+}
+
+function toggleLoading(isLoading) {
+  submitButton.disabled = isLoading;
+  submitButton.textContent = isLoading ? '生成中…' : '生成穿搭';
+}
+
+function initAutoForecast() {
+  if (!forecastStatus || !forecastList) {
+    return;
+  }
+
+  if (!('geolocation' in navigator)) {
+    updateForecastStatus('当前浏览器不支持定位功能，请使用表单获取建议。', true);
+    if (refreshForecastButton) {
+      refreshForecastButton.disabled = true;
+    }
+    return;
+  }
+
+  requestAutoForecast(false);
+}
+
+function requestAutoForecast(isRetry = false) {
+  if (!forecastStatus || !forecastList || !('geolocation' in navigator)) {
+    return;
+  }
+
+  forecastList.hidden = true;
+  updateForecastStatus(isRetry ? '重新定位中…' : '正在定位…');
+
+  if (refreshForecastButton) {
+    refreshForecastButton.disabled = true;
+  }
+
+  navigator.geolocation.getCurrentPosition(
+    (position) => {
+      fetchAutoForecast(position.coords.latitude, position.coords.longitude);
+    },
+    (error) => {
+      console.error(error);
+      let message = '定位失败，请稍后再试。';
+      if (error.code === error.PERMISSION_DENIED) {
+        message = '定位被拒绝，无法自动获取天气。';
+      }
+      updateForecastStatus(message, true);
+      if (refreshForecastButton) {
+        refreshForecastButton.disabled = false;
+      }
+    },
+    {
+      enableHighAccuracy: false,
+      timeout: 10000,
+      maximumAge: 30 * 60 * 1000,
+    },
+  );
+}
+
+async function fetchAutoForecast(latitude, longitude) {
+  if (!forecastStatus || !forecastList) {
+    return;
+  }
+
+  updateForecastStatus('正在获取 7 天天气与穿搭建议…');
+
+  try {
+    const response = await fetch('/api/auto-forecast', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ latitude, longitude }),
+    });
+
+    const payload = await response.json();
+
+    if (!response.ok || !payload.success) {
+      const message =
+        payload?.errors?.general || '天气服务暂时不可用，请稍后再试。';
+      updateForecastStatus(message, true);
+      return;
+    }
+
+    renderForecastDays(payload.data);
+  } catch (error) {
+    console.error(error);
+    updateForecastStatus('获取天气数据失败，请稍后重试。', true);
+  } finally {
+    if (refreshForecastButton) {
+      refreshForecastButton.disabled = false;
+    }
+  }
+}
+
+function renderForecastDays(data) {
+  if (!forecastList) {
+    return;
+  }
+
+  forecastList.innerHTML = '';
+
+  if (!data || !Array.isArray(data.days) || data.days.length === 0) {
+    updateForecastStatus('暂无可用的预报信息。', true);
+    forecastList.hidden = true;
+    return;
+  }
+
+  data.days.forEach((day) => {
+    forecastList.appendChild(createForecastItem(day));
+  });
+
+  forecastList.hidden = false;
+
+  const timezone = data.location?.timezone;
+  if (timezone) {
+    updateForecastStatus(`已基于你的位置（${timezone}）生成未来 7 天的穿搭建议。`);
+  } else {
+    updateForecastStatus('已基于你的位置生成未来 7 天的穿搭建议。');
+  }
+}
+
+function createForecastItem(day) {
+  const item = document.createElement('li');
+  item.className = 'forecast-item';
+
+  const header = document.createElement('div');
+  header.className = 'forecast-item-header';
+
+  const dateGroup = document.createElement('div');
+  dateGroup.className = 'forecast-date-group';
+
+  const dateText = document.createElement('p');
+  dateText.className = 'forecast-date';
+  dateText.textContent = formatDate(day?.date);
+  dateGroup.appendChild(dateText);
+
+  const weatherLine = document.createElement('p');
+  weatherLine.className = 'forecast-weather';
+  const weatherParts = [];
+  if (day?.weather_text) {
+    weatherParts.push(day.weather_text);
+  }
+  const rangeText = formatTemperatureRange(day?.temperature_min, day?.temperature_max);
+  if (rangeText) {
+    weatherParts.push(rangeText);
+  }
+  weatherLine.textContent = weatherParts.join(' · ');
+  dateGroup.appendChild(weatherLine);
+
+  header.appendChild(dateGroup);
+
+  const windText = formatWind(day?.wind_speed);
+  if (windText) {
+    const wind = document.createElement('span');
+    wind.className = 'forecast-wind';
+    wind.textContent = windText;
+    header.appendChild(wind);
+  }
+
+  item.appendChild(header);
+
+  const recommendation = day?.recommendation || {};
+
+  const outfit = document.createElement('p');
+  outfit.className = 'forecast-outfit';
+  outfit.textContent =
+    recommendation.outfit || '暂无穿搭建议，请稍后再试。';
+  item.appendChild(outfit);
+
+  const accessoriesText = formatList(recommendation.accessories, '、');
+  if (accessoriesText) {
+    const accessories = document.createElement('p');
+    accessories.className = 'forecast-extra';
+    accessories.innerHTML = `<span class="forecast-extra-label">搭配：</span>${accessoriesText}`;
+    item.appendChild(accessories);
+  }
+
+  const tipsText = formatList(recommendation.tips, '；');
+  if (tipsText) {
+    const tips = document.createElement('p');
+    tips.className = 'forecast-extra';
+    tips.innerHTML = `<span class="forecast-extra-label">提示：</span>${tipsText}`;
+    item.appendChild(tips);
+  }
+
+  return item;
+}
+
+function updateForecastStatus(message, isError = false) {
+  if (!forecastStatus) {
+    return;
+  }
+
+  forecastStatus.textContent = message;
+  forecastStatus.classList.toggle('is-error', Boolean(isError));
+}
+
+function formatDate(value) {
+  if (!value) {
+    return '日期待定';
+  }
+
+  const date = new Date(`${value}T00:00:00`);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  try {
+    return new Intl.DateTimeFormat('zh-CN', {
+      month: 'numeric',
+      day: 'numeric',
+      weekday: 'short',
+    }).format(date);
+  } catch (error) {
+    console.error(error);
+    return value;
+  }
+}
+
+function formatTemperatureRange(min, max) {
+  const minText = formatTemperature(min);
+  const maxText = formatTemperature(max);
+
+  if (minText && maxText) {
+    return `${maxText} / ${minText}`;
+  }
+  return maxText || minText || '';
+}
+
+function formatTemperature(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return '';
+  }
+  return `${Math.round(number)}°C`;
+}
+
+function formatWind(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return '';
+  }
+  return `最大风速 ${Math.round(number)} m/s`;
+}
+
+function formatList(items, separator) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return '';
+  }
+  return items.join(separator);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>智能天气穿搭助手</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
+  </head>
+  <body>
+    <div class="background-decoration"></div>
+    <header class="app-header">
+      <div class="header-content">
+        <h1>智能天气穿搭助手</h1>
+        <p>输入今日天气与体感信息，秒获贴心穿搭建议。</p>
+      </div>
+    </header>
+
+    <main class="app-container">
+      <section class="form-card">
+        <form id="recommendation-form" autocomplete="off">
+          <div class="field-group">
+            <label for="weather">今日天气</label>
+            <div class="input-with-actions">
+              <input
+                type="text"
+                id="weather"
+                name="weather"
+                placeholder="如：晴、多云、小雨"
+                required
+              />
+              <div class="quick-tags" role="list">
+                <button type="button" data-weather="晴">晴</button>
+                <button type="button" data-weather="多云">多云</button>
+                <button type="button" data-weather="小雨">小雨</button>
+                <button type="button" data-weather="大风">大风</button>
+              </div>
+            </div>
+            <p class="field-hint">支持自由输入，如“晴转多云”或“阵雨”。</p>
+            <p class="error-message" data-error-for="weather" role="alert"></p>
+          </div>
+
+          <div class="field-group inline">
+            <div>
+              <label for="temperature">气温（°C）</label>
+              <input
+                type="number"
+                id="temperature"
+                name="temperature"
+                inputmode="decimal"
+                placeholder="可选"
+              />
+              <p class="error-message" data-error-for="temperature" role="alert"></p>
+            </div>
+            <div>
+              <label for="wind">风力/风速</label>
+              <input
+                type="number"
+                id="wind"
+                name="wind"
+                inputmode="decimal"
+                placeholder="m/s，可选"
+                step="0.1"
+              />
+              <p class="error-message" data-error-for="windSpeed" role="alert"></p>
+            </div>
+          </div>
+
+          <button class="submit-button" type="submit">生成穿搭</button>
+        </form>
+      </section>
+
+      <section class="result-card" aria-live="polite">
+        <div class="placeholder" id="result-placeholder">
+          <h2>等待你的天气信息</h2>
+          <p>填写上方表单即可查看为你量身定制的穿衣方案。</p>
+        </div>
+        <article class="recommendation" id="recommendation" hidden>
+          <h2>
+            <span class="chip" id="summary-weather">晴</span>
+            <span class="chip" id="summary-temperature"></span>
+            <span class="chip" id="summary-wind"></span>
+          </h2>
+          <div class="recommendation-block">
+            <h3>推荐穿搭</h3>
+            <p id="outfit"></p>
+          </div>
+          <div class="recommendation-block" id="accessories-block" hidden>
+            <h3>建议搭配</h3>
+            <ul id="accessories"></ul>
+          </div>
+          <div class="recommendation-block" id="tips-block" hidden>
+            <h3>贴心提示</h3>
+            <ul id="tips"></ul>
+          </div>
+        </article>
+      </section>
+
+      <section class="auto-forecast-card">
+        <div class="forecast-header">
+          <div>
+            <h2>未来 7 天智能穿搭</h2>
+            <p id="forecast-status" class="forecast-status" aria-live="polite">
+              正在为你定位并获取天气…
+            </p>
+          </div>
+          <button type="button" class="refresh-forecast" id="refresh-forecast">
+            重新定位
+          </button>
+        </div>
+        <ul id="forecast-list" class="forecast-list" hidden></ul>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p>根据你的天气输入提供灵活的穿搭指南，助你舒适出行。</p>
+    </footer>
+
+    <script src="{{ url_for('static', filename='js/app.js') }}" defer></script>
+  </body>
+</html>

--- a/test.py
+++ b/test.py
@@ -1,1 +1,253 @@
-print("FUCK YOU GITHUB1!")
+"""Web 版智能天气穿搭助手。"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import requests
+from flask import Flask, jsonify, render_template, request
+
+from weather_assistant import (
+    WeatherAssistant,
+    describe_open_meteo_code,
+    parse_optional_float,
+)
+
+app = Flask(__name__)
+assistant = WeatherAssistant()
+
+
+@app.route("/")
+def index() -> str:
+    """展示主页面。"""
+
+    return render_template("index.html")
+
+
+@app.post("/api/recommend")
+def recommend() -> Tuple[Any, int]:
+    """根据请求参数返回穿衣建议。"""
+
+    payload: Dict[str, Any] = request.get_json(silent=True) or {}
+    if not payload and request.form:
+        payload = request.form.to_dict(flat=True)
+
+    weather = str(payload.get("weather", ""))
+    temperature_input = payload.get("temperature")
+    wind_input = payload.get("windSpeed")
+
+    errors: Dict[str, str] = {}
+    temperature = None
+    wind_speed = None
+
+    if not weather.strip():
+        errors["weather"] = "请输入天气描述"
+
+    try:
+        temperature = _normalize_maybe_number(temperature_input)
+    except ValueError as exc:
+        errors["temperature"] = str(exc)
+
+    try:
+        wind_speed = _normalize_maybe_number(wind_input)
+    except ValueError as exc:
+        errors["windSpeed"] = str(exc)
+
+    if errors:
+        return jsonify({"success": False, "errors": errors}), 400
+
+    try:
+        recommendation = assistant.suggest_outfit(weather, temperature, wind_speed)
+    except ValueError as exc:
+        return jsonify({"success": False, "errors": {"weather": str(exc)}}), 400
+
+    return jsonify({"success": True, "data": recommendation.to_dict()}), 200
+
+
+@app.post("/api/auto-forecast")
+def auto_forecast() -> Tuple[Any, int]:
+    """根据经纬度自动查询未来七天的天气与穿搭建议。"""
+
+    payload: Dict[str, Any] = request.get_json(silent=True) or {}
+    latitude_raw = payload.get("latitude")
+    longitude_raw = payload.get("longitude")
+
+    errors: Dict[str, str] = {}
+    try:
+        latitude = _normalize_coordinate(latitude_raw)
+    except ValueError as exc:
+        errors["latitude"] = str(exc)
+        latitude = None
+
+    try:
+        longitude = _normalize_coordinate(longitude_raw)
+    except ValueError as exc:
+        errors["longitude"] = str(exc)
+        longitude = None
+
+    if errors:
+        return jsonify({"success": False, "errors": errors}), 400
+
+    try:
+        forecast_raw = _fetch_forecast(latitude, longitude)
+    except RuntimeError as exc:
+        return (
+            jsonify({"success": False, "errors": {"general": str(exc)}}),
+            502,
+        )
+
+    try:
+        days = _build_forecast_days(forecast_raw)
+    except ValueError as exc:
+        return (
+            jsonify({"success": False, "errors": {"general": str(exc)}}),
+            502,
+        )
+
+    if not days:
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "errors": {"general": "暂未获取到天气数据，请稍后重试。"},
+                }
+            ),
+            502,
+        )
+
+    response_payload = {
+        "location": {
+            "latitude": latitude,
+            "longitude": longitude,
+            "timezone": forecast_raw.get("timezone"),
+        },
+        "days": days,
+    }
+
+    return jsonify({"success": True, "data": response_payload}), 200
+
+
+def _normalize_maybe_number(value: Any) -> float | None:
+    """解析可能为字符串的数值，保持空值为 None。"""
+
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return parse_optional_float(str(value))
+
+
+def _normalize_coordinate(value: Any) -> float:
+    """解析地理坐标，确保为浮点数。"""
+
+    if value in (None, ""):
+        raise ValueError("未能获取定位信息")
+
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("定位数据格式有误") from exc
+
+
+def _fetch_forecast(latitude: float, longitude: float) -> Dict[str, Any]:
+    """调用 Open-Meteo 接口获取七天预报。"""
+
+    params = {
+        "latitude": latitude,
+        "longitude": longitude,
+        "daily": "weathercode,temperature_2m_max,temperature_2m_min,windspeed_10m_max",
+        "timezone": "auto",
+        "forecast_days": 7,
+    }
+    try:
+        response = requests.get(
+            "https://api.open-meteo.com/v1/forecast", params=params, timeout=10
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:  # pragma: no cover - 需网络环境
+        raise RuntimeError("天气服务暂时不可用，请稍后再试。") from exc
+
+    try:
+        data: Dict[str, Any] = response.json()
+    except ValueError as exc:  # pragma: no cover - 第三方异常
+        raise RuntimeError("天气服务返回了无效的数据。") from exc
+
+    return data
+
+
+def _build_forecast_days(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """将天气预报数据转换为前端可用的结构。"""
+
+    daily = data.get("daily")
+    if not isinstance(daily, dict):
+        raise ValueError("天气服务暂未提供未来七天天气数据。")
+
+    dates = list(daily.get("time") or [])
+    weather_codes = list(daily.get("weathercode") or [])
+    temps_max = list(daily.get("temperature_2m_max") or [])
+    temps_min = list(daily.get("temperature_2m_min") or [])
+    winds = list(daily.get("windspeed_10m_max") or [])
+
+    days: List[Dict[str, Any]] = []
+    for index, date_str in enumerate(dates[:7]):
+        code_raw = weather_codes[index] if index < len(weather_codes) else None
+        category, description = describe_open_meteo_code(code_raw)
+
+        max_temp = _safe_get_float(temps_max, index)
+        min_temp = _safe_get_float(temps_min, index)
+        wind_speed = _safe_get_float(winds, index)
+
+        averaged_temp = _average_temperature(max_temp, min_temp)
+
+        recommendation = assistant.suggest_outfit(
+            category, temperature=averaged_temp, wind_speed=wind_speed
+        )
+
+        try:
+            weather_code = int(code_raw) if code_raw is not None else None
+        except (TypeError, ValueError):  # pragma: no cover - 容错逻辑
+            weather_code = None
+
+        days.append(
+            {
+                "date": date_str,
+                "weather_text": description,
+                "weather_code": weather_code,
+                "temperature_max": max_temp,
+                "temperature_min": min_temp,
+                "wind_speed": wind_speed,
+                "recommendation": recommendation.to_dict(),
+            }
+        )
+
+    return days
+
+
+def _average_temperature(max_temp: float | None, min_temp: float | None) -> float | None:
+    """根据最高与最低气温计算平均值。"""
+
+    temps = [value for value in (max_temp, min_temp) if value is not None]
+    if not temps:
+        return None
+    return sum(temps) / len(temps)
+
+
+def _safe_get_float(values: List[Any], index: int) -> float | None:
+    """安全地从列表中取出浮点值。"""
+
+    try:
+        value = values[index]
+    except (IndexError, TypeError):
+        return None
+
+    if value in (None, ""):
+        return None
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/weather_assistant.py
+++ b/weather_assistant.py
@@ -1,0 +1,247 @@
+"""核心逻辑：根据天气信息生成穿搭建议。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class _RecommendationTemplate:
+    """模板，用于描述某种天气下的基础穿衣建议。"""
+
+    outfit: str
+    accessories: Tuple[str, ...] = ()
+    tips: Tuple[str, ...] = ()
+
+
+@dataclass
+class OutfitRecommendation:
+    """具体的穿衣推荐结果。"""
+
+    outfit: str
+    accessories: List[str] = field(default_factory=list)
+    tips: List[str] = field(default_factory=list)
+
+    def format(self) -> str:
+        """格式化穿衣建议，方便展示。"""
+
+        lines: List[str] = [f"推荐穿搭：{self.outfit}"]
+        if self.accessories:
+            lines.append("建议搭配：" + "、".join(self.accessories))
+        if self.tips:
+            lines.append("贴心提示：" + "；".join(self.tips))
+        return "\n".join(lines)
+
+    def to_dict(self) -> Dict[str, List[str] | str]:
+        """转换为便于序列化的结构。"""
+
+        data = asdict(self)
+        return data
+
+
+class WeatherAssistant:
+    """智能天气助手，可以根据不同天气给出穿搭建议。"""
+
+    #: 常见天气的别名，用于提升识别率。
+    _ALIASES: Dict[str, str] = {
+        "晴": "sunny",
+        "晴天": "sunny",
+        "晴朗": "sunny",
+        "多云": "cloudy",
+        "阴": "cloudy",
+        "阴天": "cloudy",
+        "雨": "rainy",
+        "下雨": "rainy",
+        "小雨": "rainy",
+        "大雨": "rainy",
+        "雷阵雨": "storm",
+        "暴雨": "storm",
+        "雪": "snowy",
+        "下雪": "snowy",
+        "大雪": "snowy",
+        "小雪": "snowy",
+        "雾": "foggy",
+        "雾霾": "foggy",
+        "风": "windy",
+        "大风": "windy",
+        "沙尘": "windy",
+        "沙尘暴": "windy",
+    }
+
+    def __init__(self) -> None:
+        self._templates: Dict[str, _RecommendationTemplate] = {
+            "sunny": _RecommendationTemplate(
+                "轻薄长袖或短袖上衣，搭配舒适长裤或裙装",
+                ("太阳镜", "防晒霜"),
+                ("中午紫外线较强时尽量戴帽子",),
+            ),
+            "cloudy": _RecommendationTemplate(
+                "薄外套配长裤，内搭透气上衣",
+                ("轻便运动鞋",),
+                ("天气多变，出门前留意是否会转雨",),
+            ),
+            "rainy": _RecommendationTemplate(
+                "防水外套或带帽雨衣，搭配快干长裤",
+                ("雨伞", "防水鞋"),
+                ("尽量避免穿布鞋，回家后及时烘干衣物",),
+            ),
+            "storm": _RecommendationTemplate(
+                "防水风衣加保暖内搭",
+                ("长筒雨靴", "防水背包"),
+                ("尽量减少外出，注意雷电安全",),
+            ),
+            "snowy": _RecommendationTemplate(
+                "厚实羽绒服或呢大衣，内搭羊毛衫",
+                ("防滑雪地靴", "保暖手套"),
+                ("外出前在鞋底贴防滑贴，注意路面结冰",),
+            ),
+            "foggy": _RecommendationTemplate(
+                "保暖外套配长裤",
+                ("口罩", "护目镜"),
+                ("雾霾天尽量减少户外运动，回家及时清洁面部",),
+            ),
+            "windy": _RecommendationTemplate(
+                "防风外套配长裤",
+                ("围巾",),
+                ("骑行或长时间户外活动时注意防风保暖",),
+            ),
+            "default": _RecommendationTemplate(
+                "舒适的分层穿搭，如 T 恤配开衫",
+                ("随身携带一件薄外套以防温差",),
+                ("留意实时天气预报，适时增减衣物",),
+            ),
+        }
+
+    def suggest_outfit(
+        self,
+        weather: str,
+        temperature: Optional[float] = None,
+        wind_speed: Optional[float] = None,
+    ) -> OutfitRecommendation:
+        """根据天气、气温和风力情况生成穿衣建议。"""
+
+        if not weather or not weather.strip():
+            raise ValueError("weather 不能为空")
+
+        normalized_weather = self._normalize_weather(weather)
+        template = self._templates.get(normalized_weather, self._templates["default"])
+        accessories = list(template.accessories)
+        tips = list(template.tips)
+        outfit = template.outfit
+
+        if temperature is not None:
+            outfit, accessories, tips = self._adjust_by_temperature(
+                temperature, outfit, accessories, tips
+            )
+
+        if wind_speed is not None:
+            tips = self._adjust_by_wind(wind_speed, tips, accessories)
+
+        return OutfitRecommendation(outfit=outfit, accessories=accessories, tips=tips)
+
+    def _normalize_weather(self, weather: str) -> str:
+        key = weather.strip().lower()
+        return self._ALIASES.get(key, key)
+
+    def _adjust_by_temperature(
+        self,
+        temperature: float,
+        outfit: str,
+        accessories: List[str],
+        tips: List[str],
+    ) -> Tuple[str, List[str], List[str]]:
+        """根据气温调整穿搭。"""
+
+        if temperature <= 5:
+            outfit = "保暖羽绒服或厚呢大衣，内搭羊毛衫与保暖裤"
+            if "保暖帽" not in accessories:
+                accessories.extend(["保暖帽", "围巾"])
+            tips.append("室内外温差大时注意及时增减衣物")
+        elif temperature <= 15:
+            outfit = "针织衫或卫衣外搭中等厚度外套，下装长裤"
+            if "薄围巾" not in accessories:
+                accessories.append("薄围巾")
+            tips.append("早晚偏凉，可准备一件轻薄内搭")
+        elif temperature >= 28:
+            outfit = "透气短袖或无袖上衣，搭配短裤或轻薄长裤"
+            if "遮阳帽" not in accessories:
+                accessories.append("遮阳帽")
+            tips.append("多喝水，避免长时间暴晒")
+        elif temperature >= 22:
+            tips.append("气温较高，选择吸汗面料会更舒适")
+        else:
+            tips.append("气温适中，保持分层穿搭以便调节")
+
+        return outfit, accessories, tips
+
+    def _adjust_by_wind(
+        self,
+        wind_speed: float,
+        tips: List[str],
+        accessories: List[str],
+    ) -> List[str]:
+        """根据风力调整提示。"""
+
+        if wind_speed >= 10:
+            if "防风外套" not in accessories:
+                accessories.append("防风外套")
+            tips.append("风力较大，外出时注意防风并保护好头部")
+        elif wind_speed >= 5:
+            tips.append("有明显风感，骑行或长时间户外活动时注意防风")
+        return tips
+
+
+def parse_optional_float(value: str) -> Optional[float]:
+    """将字符串转换为浮点数，空值返回 None。"""
+
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError as exc:  # noqa: PERF203 - 简单脚本，不考虑极致性能
+        raise ValueError("请输入有效的数字") from exc
+
+
+_OPEN_METEO_CODE_MAPPING: Dict[int, Tuple[str, str]] = {
+    0: ("sunny", "晴朗"),
+    1: ("sunny", "多云转晴"),
+    2: ("cloudy", "局部多云"),
+    3: ("cloudy", "阴"),
+    45: ("foggy", "有雾"),
+    48: ("foggy", "雾凇"),
+    51: ("rainy", "毛毛雨"),
+    53: ("rainy", "小雨"),
+    55: ("rainy", "中雨"),
+    56: ("rainy", "冻雨"),
+    57: ("rainy", "冻雨"),
+    61: ("rainy", "小雨"),
+    63: ("rainy", "中雨"),
+    65: ("rainy", "大雨"),
+    66: ("rainy", "冻雨"),
+    67: ("rainy", "冻雨"),
+    71: ("snowy", "小雪"),
+    73: ("snowy", "中雪"),
+    75: ("snowy", "大雪"),
+    77: ("snowy", "阵雪"),
+    80: ("rainy", "阵雨"),
+    81: ("rainy", "阵雨"),
+    82: ("rainy", "暴雨"),
+    85: ("snowy", "阵雪"),
+    86: ("snowy", "暴雪"),
+    95: ("storm", "雷暴"),
+    96: ("storm", "雷暴伴冰雹"),
+    99: ("storm", "雷暴伴强冰雹"),
+}
+
+
+def describe_open_meteo_code(code: int | str) -> Tuple[str, str]:
+    """根据 Open-Meteo 的天气编码返回穿搭助手所需的类别与描述。"""
+
+    try:
+        normalized_code = int(code)
+    except (TypeError, ValueError):
+        return "default", "多变天气"
+
+    return _OPEN_METEO_CODE_MAPPING.get(normalized_code, ("default", "多变天气"))


### PR DESCRIPTION
## Summary
- add a Flask endpoint that queries Open-Meteo with the user coordinates to build seven-day outfit recommendations with the existing assistant
- expose Open-Meteo weather-code normalization helpers and reuse them to keep mapping logic consistent
- refresh the UI with a geolocation-aware 7-day planner card, associated styling, and documentation for the new automation flow

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf5996ca688330b57c3ba4244fed1f